### PR TITLE
Support imjoy api

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -12,9 +12,9 @@ mkdir -p dist
 cd dist
 
 { # try to download from github release
-    wget https://github.com/imjoy-team/imagej.js/releases/download/0.1.x/imagej-1.zip
-    unzip -q -o imagej-1.zip
-    rm imagej-1.zip
+    wget https://github.com/imjoy-team/imagej.js/releases/download/0.1.x/imagej-1-packed.zip
+    unzip -q -o imagej-1-packed.zip
+    rm imagej-1-packed.zip
 } || { # if failed then compile
     wget https://d3415aa6bfa4.leaningtech.com/cheerpj_linux_2.1.tar.gz
     tar -xvf cheerpj_linux_2.1.tar.gz

--- a/compile.sh
+++ b/compile.sh
@@ -49,9 +49,9 @@ then
     mv ij-packed.jar ij.jar
     rm plugins/Thunder_STORM.jar
     mv plugins/Thunder_STORM-packed.jar plugins/Thunder_STORM.jar
-    rm ImageJ.app
     rm ImageJ.exe
     rm run
+    rm -rf ImageJ.app
 
     # python build_plugins.py
     # ${CHEERPJ_DIR}/cheerpjfy.py --pack-jar=plugins-packed.jar plugins.jar

--- a/compile.sh
+++ b/compile.sh
@@ -3,32 +3,65 @@
 # Install it and change the following CHEERPJ_DIR to the root path of your cheerpj installation
 # The following export line assumes you insalled it to /Applications/cheerpj
 # also you need to uncomment it to run
-# export CHEERPJ_DIR=/Applications/cheerpj # <------change this accordingly
 
+# Usage:
+#  1. compile from scratch: COMPILE=1 bash compile.sh
+#  2. provide cheerpj binary for compilation:  COMPILE=1 CHEERPJ_DIR=/Applications/cheerpj bash compile.sh
+#  3. download precompiled: unset COMPILE && bash compile.sh
 
 
 # the compiled files will be saved in ./dist
 mkdir -p dist
 cd dist
 
-{ # try to download from github release
-    wget https://github.com/imjoy-team/imagej.js/releases/download/0.1.x/imagej-1-packed.zip
+if [ -n COMPILE ]
+then
+    # compile from scratch
+
+    if test -z CHEERPJ_DIR
+    then
+        curl https://d3415aa6bfa4.leaningtech.com/cheerpj_linux_2.1.tar.gz -LO
+        tar -xvf cheerpj_linux_2.1.tar.gz
+        export CHEERPJ_DIR=$(pwd)/cheerpj_2.1
+    fi
+    
+    # # download imagej-1 from imagej.net
+    export IJ1_VERSION=ij153
+    curl http://wsr.imagej.net/distros/cross-platform/${IJ1_VERSION}.zip -LO
+    unzip -q -o ${IJ1_VERSION}.zip
+    rm ${IJ1_VERSION}.zip
+    rm -rf ${IJ1_VERSION}
+    mv ImageJ ${IJ1_VERSION}
+
+    # # compile ij.jar and we should get
+    cd ${IJ1_VERSION}
+    ${CHEERPJ_DIR}/cheerpjfy.py  --pack-jar=ij-packed.jar ij.jar
+
+
+    # download thunderSTORM
+    curl https://github.com/zitmen/thunderstorm/releases/download/v1.3/Thunder_STORM.jar -LO
+    mv Thunder_STORM.jar plugins/Thunder_STORM.jar
+    ${CHEERPJ_DIR}/cheerpjfy.py --deps=ij.jar --pack-jar=plugins/Thunder_STORM-packed.jar plugins/Thunder_STORM.jar
+
+
+    # replace with the packed version
+    rm ij.jar
+    mv ij-packed.jar ij.jar
+    rm plugins/Thunder_STORM.jar
+    mv plugins/Thunder_STORM-packed.jar plugins/Thunder_STORM.jar
+    rm ImageJ.app
+    rm ImageJ.exe
+    rm run
+
+    # python build_plugins.py
+    # ${CHEERPJ_DIR}/cheerpjfy.py --pack-jar=plugins-packed.jar plugins.jar
+
+else
+
+    # try to download from github release
+    curl https://github.com/imjoy-team/imagej.js/releases/download/0.1.x/imagej-1-packed.zip -LO
     unzip -q -o imagej-1-packed.zip
     rm imagej-1-packed.zip
-} || { # if failed then compile
-    wget https://d3415aa6bfa4.leaningtech.com/cheerpj_linux_2.1.tar.gz
-    tar -xvf cheerpj_linux_2.1.tar.gz
-    export CHEERPJ_DIR=$(pwd)/cheerpj_2.1
-    # download imagej-1 from imagej.net
-    curl http://wsr.imagej.net/distros/cross-platform/ij153.zip --output ./ij.zip
-    unzip -q -o ij.zip
-    rm ij.zip
-    mv ImageJ imagej-1
 
-    # compile ij.jar and we should get
-    cd imagej-1
-    ${CHEERPJ_DIR}/cheerpjfy.py ij.jar
-    python build_plugins.py
-    ${CHEERPJ_DIR}/cheerpjfy.py plugins.jar
-}
+fi
 

--- a/compile.sh
+++ b/compile.sh
@@ -59,9 +59,9 @@ then
 else
 
     # try to download from github release
-    curl https://github.com/imjoy-team/imagej.js/releases/download/0.1.x/imagej-1-packed.zip -LO
-    unzip -q -o imagej-1-packed.zip
-    rm imagej-1-packed.zip
+    curl https://github.com/imjoy-team/imagej.js/releases/download/0.1.x/ij153.zip -LO
+    unzip -q -o ij153.zip
+    rm ij153.zip
 
 fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8527,6 +8527,11 @@
       "requires": {
         "minimatch": "^3.0.4"
       }
+    },
+    "imjoy-rpc": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/imjoy-rpc/-/imjoy-rpc-0.2.22.tgz",
+      "integrity": "sha512-1mWNRQt790+MTdpWOfubNLDON9sfB7WpKTXA/1RHgKyHSacpYjTlSqe0a90BJK+fjGx+5nK50QVpWtPrNjVbvg=="
     },
     "import-fresh": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "ImageJ running in the browser",
   "main": "lib/index.js",
   "module": "src/index.js",
@@ -35,7 +35,8 @@
   },
   "homepage": "https://github.com/imjoy-team/imagej.js#readme",
   "dependencies": {
-    "@jupyterlab/services": "^4.2.0"
+    "@jupyterlab/services": "^4.2.0",
+    "imjoy-rpc": "^0.2.22"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.39",

--- a/src/imjoyAPI.js
+++ b/src/imjoyAPI.js
@@ -47,6 +47,11 @@ export async function setupImJoyAPI(imagej, getImageData) {
       }
 
     },
+    async getSelection() {
+      const imp = await imagej.getImage();
+      const bytes = await saveFileToBytes(imagej, imp, 'selection', 'tmp')
+      return bytes
+    },
     async getImage() {
 
       const data = await getImageData(imagej);

--- a/src/imjoyAPI.js
+++ b/src/imjoyAPI.js
@@ -1,0 +1,28 @@
+import {
+  setupRPC
+} from 'imjoy-rpc';
+
+export async function setupImJoyAPI(imagej) {
+  const api = await setupRPC({
+    name: "ImageJ.JS",
+    version: "0.1.0",
+    description: "ImageJ running in the browser",
+    type: "rpc-window"
+  });
+
+  const service_api = {
+    setup() {
+      api.log("ImageJ.JS loaded successfully.");
+    },
+    async run(ctx) {
+      if (ctx.data && ctx.data.images) {
+        //TODO: load images
+      }
+    },
+    async getImage() {
+      return imagej.getImage();
+    }
+  };
+
+  api.export(service_api);
+}

--- a/src/imjoyAPI.js
+++ b/src/imjoyAPI.js
@@ -2,7 +2,7 @@ import {
   setupRPC
 } from 'imjoy-rpc';
 
-export async function setupImJoyAPI(imagej) {
+export async function setupImJoyAPI(imagej, getImageData) {
   const api = await setupRPC({
     name: "ImageJ.JS",
     version: "0.1.0",
@@ -17,10 +17,52 @@ export async function setupImJoyAPI(imagej) {
     async run(ctx) {
       if (ctx.data && ctx.data.images) {
         //TODO: load images
+        for (let img of ctx.data.images) {
+          this.addImage(img);
+        }
       }
     },
+    async addImage(img, options) {
+      options = options || {}
+      options.name = options.name || "tmp"
+      const filepath = "/str/" + options.name
+      const formats = {
+        "uint8": "8-bit",
+        "uint16": "16-bit Unsigned",
+        "int16": "16-bit Signed",
+        "uint32": "32-bit Unsigned",
+        "int32": "32-bit Signed",
+      }
+      cheerpjAddStringFile(filepath, new Uint8Array(img._rvalue));
+      let format = formats[img._rdtype];
+      let number = img._rshape[2];
+      if (img._rshape.length === 3) {
+        if (img._rshape[2] === 3) {
+          format = '[24-bit RGB]'
+          number = 1;
+        }
+        return await imagej.run("Raw...", `open=${filepath} image=${format} width=${img._rshape[1]} height=${img._rshape[0]} number=${number}`)
+      } else if (img._rshape.length === 2) {
+        return await imagej.run("Raw...", `open=${filepath} image=${format} width=${img._rshape[1]} height=${img._rshape[0]}`)
+      }
+
+    },
     async getImage() {
-      return imagej.getImage();
+
+      const data = await getImageData(imagej);
+      const types = {
+        0: "uint8", //GRAY8
+        1: "int16", //GRAY16
+        2: "uint16", //	GRAY16_UNSIGNED
+        3: "uint8", //RGB
+        4: "float32", //GRAY32_FLOAT
+      }
+      return {
+        _rtype: "ndarray",
+        _rvalue: data.bytes,
+        _rshape: data.shape,
+        _rdtype: types[data.type]
+      }
     }
   };
 

--- a/src/index.html
+++ b/src/index.html
@@ -77,8 +77,13 @@
       min-height: 20px;
     }
 
+    /* fix search dialog */
+    .window>div>div>div>div {
+      width: 100% !important;
+    }
+
     .window>div>input {
-      height: 15px!important;
+      height: 15px !important;
     }
 
     #drag-overlay {
@@ -104,6 +109,7 @@
 
 <body>
   <div id="drag-overlay">
+    <input type="file" id="open-file" style="display: none;">
     <span>Drop file here to open</span>
   </div>
   <div class="container" id="app-container">

--- a/src/index.html
+++ b/src/index.html
@@ -74,6 +74,11 @@
     .window>div>div {
       width: 100% !important;
       background-color: transparent !important;
+      min-height: 20px;
+    }
+
+    .window>div>input {
+      height: 15px!important;
     }
 
     #drag-overlay {

--- a/src/index.js
+++ b/src/index.js
@@ -296,6 +296,6 @@ startImageJ().then((imagej) => {
 
     // if inside an iframe, setup ImJoy
     if (window.self !== window.top) {
-        setupImJoyAPI(imagej, getImageData);
+        setupImJoyAPI(imagej, getImageData, saveFileToBytes);
     }
 })

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ async function startImageJ() {
     cheerpjCreateDisplay(-1, -1, appContainer);
     cheerpjRunStaticMethod(threads[0], "java/lang/System", cjSystemSetProperty, "user.dir", "/files");
     cheerpjRunStaticMethod(threads[0], "java/lang/System", cjSystemSetProperty, "plugins.dir", "/app/imagej-1");
-    cheerpjRunMain("ij.ImageJ", "/app/imagej-1/ij.jar:/app/imagej-1/plugins/Thunder_STORM.jar");
+    cheerpjRunMain("ij.ImageJ", "/app/ij153/ij.jar:/app/ij153/plugins/Thunder_STORM.jar");
 
     const ij = await getImageJInstance()
     // turn on debug mode


### PR DESCRIPTION
This PR add ImJoy api to imagej.js

```python
from imjoy import api
import numpy as np
import imageio

class ImJoyPlugin():
    async def setup(self):
        pass

    async def run(self, ctx):
        ij = await api.createWindow(src="https://ij.imjoy.io/")
        image = imageio.imread("https://images.unsplash.com/photo-1508138221679-760a23a2285b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60")
        await ij.addImage(image[:, :, 1], name="my-image")
        d = await ij.getImage()
        api.alert(d.shape)

api.export(ImJoyPlugin())
```

<img width="1249" alt="Screenshot 2020-08-28 at 01 57 31" src="https://user-images.githubusercontent.com/478667/91506202-d9511500-e8d1-11ea-86fb-47bd009a5596.png">
