### PR TITLE
Fix opening sample images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "ImageJ running in the browser",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,19 @@ window.openURL = async (url) => {
   window.open(url);
 }
 
+window.getBytesFromUrl = async (url, promise)=>{
+  url = "https://cors-anywhere.herokuapp.com/" + url.replace("http://", "https://");
+  try{
+    const blob = await fetch(url).then(r => r.blob());
+    const buffer = await blob.arrayBuffer();
+    await cjCall(promise, "resolve", cjTypedArrayToJava(new Uint8Array(buffer)));
+  }
+  catch(e){
+    console.error("Failed to get data from " + url, e);
+    await cjCall(promise, "reject", e.toString());
+  }
+}
+
 const downloadQueue = {};
 
 async function startImageJ() {
@@ -191,6 +204,7 @@ async function startImageJ() {
   window.ij = imagej_api;
   return imagej_api;
 }
+
 
 async function listFiles(imagej, path) {
   const files = await imagej.listDir(path)
@@ -310,8 +324,8 @@ async function saveFileToFS(imagej, file) {
 
 async function fixMenu(imagej) {
   const removes = [
-    "Open Samples",
     "Show Folder",
+    "Update ImageJ...",
     "Compile and Run...",
     "Capture Screen",
     "Capture Delayed...",

--- a/src/style.css
+++ b/src/style.css
@@ -16,7 +16,7 @@ body {
 
 ::-webkit-scrollbar-thumb {
     border-radius: 4px;
-    background-color: rgba(0, 0, 0, .5);
+    background-color: rgba(0, 0, 0, .25);
     -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, .5);
 }
 


### PR DESCRIPTION
This PR aims to fix the loading samples from URL, the original java version manipulate sockets directly which is not accessible for the browser version. This PR creates a javascript function for handling download, also see here: https://github.com/imjoy-team/ImageJA/commit/379721a49dd2157d1a036e325a21044a55bd981b