### PR TITLE
Remove cors proxy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,11 +98,6 @@ window.getBytesFromUrl = async (originalUrl, promise) => {
   try {
     loader.style.display = "block";
     let url = originalUrl.replace("http://", "https://");
-    // use proxy for imagej.net for now
-    // TODO: fix this when imagej.net supports CORS
-    if(url.includes("imagej.net")){
-      url = "https://cors-anywhere.herokuapp.com/" + url
-    }
     Snackbar.show({
       text: "Fetching data from: " + originalUrl,
       pos: "bottom-left"


### PR DESCRIPTION
Thanks to @ctrueden CORS is now enabled (https://github.com/imagej/imagej/issues/256) for imagej.net, so we can remove the CORS proxy.