### PR TITLE
Add api to support install macro and tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ ij = await api.createWindow(src="https://ij.imjoy.io")
 await ij.runMacro("close();")
 ```
 
+### installMacro(macro)
+Install a macro (string).
+```python
+ij = await api.createWindow(src="https://ij.imjoy.io")
+
+myMacro = open("my_macro_to_install.ijm", "r").read()
+await ij.installMacro(myMacro)
+```
+
+### installTool(tool)
+Install a macro tool (string).
+```python
+ij = await api.createWindow(src="https://ij.imjoy.io")
+
+myMacroTool = open("my_macro_tool_to_install.ijm", "r").read()
+await ij.installTool(myMacroTool)
+```
+
 ### runPlugIn(className, args)
 Run plugin by its class name with an optional arguments.
 

--- a/examples/getting-started.ipynb
+++ b/examples/getting-started.ipynb
@@ -39,7 +39,7 @@
     "        \n",
     "    async def run(self, ctx):\n",
     "        # load the ImageJ.JS window\n",
-    "        self.ij = await api.createWindow(src=\"http://127.0.0.1:9090\")\n",
+    "        self.ij = await api.createWindow(src=\"https://ij.imjoy.io\")\n",
     "\n",
     "        # show an image\n",
     "        await self.ij.viewImage(image, name=\"my-image\")\n",
@@ -77,7 +77,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.8-final"
   }
  },
  "nbformat": 4,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "ImageJ running in the browser",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/imjoyAPI.js
+++ b/src/imjoyAPI.js
@@ -61,6 +61,24 @@ export async function setupImJoyAPI(
         loader.style.display = "none";
       }
     },
+    async installMacro(macro) {
+      try {
+        await imagej.installMacro(macro);
+      } catch (e) {
+        throw e;
+      } finally {
+        loader.style.display = "none";
+      }
+    },
+    async installTool(tool) {
+      try {
+        await imagej.installTool(tool);
+      } catch (e) {
+        throw e;
+      } finally {
+        loader.style.display = "none";
+      }
+    },
     runPlugIn(className, args) {
       imagej.runPlugIn(className, args || "");
     },

--- a/src/index.js
+++ b/src/index.js
@@ -610,6 +610,12 @@ window.onImageJInitialized = async () => {
       "java.lang.String",
       "java.lang.String"
     ]),
+    installMacro: await cjResolveCall("ij.IJ", "installMacro", [
+      "java.lang.String"
+    ]),
+    installTool: await cjResolveCall("ij.IJ", "installTool", [
+      "java.lang.String"
+    ]),
     open: await cjResolveCall("ij.IJ", "open", ["java.lang.String"]),
     installPlugin: await cjResolveCall("ij.Menus", "installPlugin", null),
     getPlugins: await cjResolveCall("ij.Menus", "getPlugins", []),


### PR DESCRIPTION
This PR adds two new API for ImJoy: `installMacro()` and `installTool()`, see README for details.