### PR TITLE
Support loading image and macro from Zenodo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "ImageJ running in the browser",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/utils.js
+++ b/src/utils.js
@@ -186,3 +186,21 @@ export async function githubUrlRaw(url, extFilter) {
     regStr
   );
 }
+
+export async function convertZenodoFileUrl(url) {
+  const myRegexp = /https?:\/\/zenodo.org\/record\/([a-zA-Z0-9-]+)\/files\/(.*)/g;
+  const match = myRegexp.exec(url);
+  if (!match || match.length !== 3) {
+    throw new Error("Invalid zenodo url");
+  }
+  const [fullUrl, depositId, fileName] = match;
+  const blob = await fetch(
+    `https://zenodo.org/api/records/${depositId}`
+  ).then(r => r.blob());
+  const data = JSON.parse(await new Response(blob).text());
+  const fn = fileName.split("?")[0];
+  const fileObj = data.files.filter(file => {
+    return file.key === fn;
+  })[0];
+  return fileObj.links.self;
+}


### PR DESCRIPTION
> Zenodo is a general-purpose open-access repository developed under the European OpenAIRE program and operated by CERN. 

This PR allows fetch files from zenodo and load into ImageJ.JS.
For example, this deposit contains a file: https://zenodo.org/record/1069732

If we copy the file url we get: `https://zenodo.org/record/1069732/files/BLL825_INDCH60R_01_L.tif?download=1`

With this PR, we can simply open this image by `https://ij.imjoy.io?open=https://zenodo.org/record/1069732/files/BLL825_INDCH60R_01_L.tif`

@mutterer I think you can then extend your chrome extension to enable "Open with ImageJ.JS" on zenodo site!

