### PR TITLE
Upgrade loader and fix-open-async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "ImageJ running in the browser",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/imjoyApp.js
+++ b/src/imjoyApp.js
@@ -1,6 +1,7 @@
 import Snackbar from "node-snackbar/dist/snackbar";
 
 const builtinPlugins = [
+  "https://gist.githubusercontent.com/oeway/9c78d23c101f468e723888d05b6fac6d/raw/ImageJScriptEditor.imjoy.html",
   "https://gist.githubusercontent.com/oeway/c9592f23c7ee147085f0504d2f3e993a/raw/CellPose-ImageJ.imjoy.html",
   "https://gist.githubusercontent.com/oeway/e5c980fbf6582f25fde795262a7e33ec/raw/itk-vtk-viewer-imagej.imjoy.html"
 ];
@@ -131,7 +132,7 @@ async function startImJoy(app, imjoy) {
         app.plugins[plugin.name] = plugin;
         app.$forceUpdate();
         if (plugin.api && plugin.api.run) {
-          plugin.api.run({});
+          plugin.api.run({ config: {}, data: {} });
         } else {
           Snackbar.show({
             text: `No "run" function defined in Plugin "${plugin.name}".`,
@@ -193,7 +194,7 @@ async function startImJoy(app, imjoy) {
       }
 
       const result = await plugin[functionName].apply(plugin, args);
-      if (promise) {
+      if (promise && typeof promise === "function") {
         if (typeof result === "string") {
           await cjCall(promise, "resolveString", result);
         } else if (result._rtype === "ndarray") {
@@ -408,7 +409,7 @@ export async function setupImJoyApp(setAPI) {
           .then(enginePlugin => {
             const queryString = window.location.search;
             const urlParams = new URLSearchParams(queryString);
-            const engine = queryString.get("engine");
+            const engine = urlParams.get("engine");
             const spec = urlParams.get("spec");
             if (engine) {
               enginePlugin.api

--- a/src/index.html
+++ b/src/index.html
@@ -27,7 +27,7 @@
     />
     <title>ImageJ.JS</title>
     <link rel="stylesheet" href="/style.css" />
-    <script src="https://cjrtnc.leaningtech.com/20201216/loader.js"></script>
+    <script src="https://cjrtnc.leaningtech.com/20201217_2/loader.js"></script>
     <link
       rel="apple-touch-icon"
       sizes="48x48"

--- a/src/index.js
+++ b/src/index.js
@@ -38,18 +38,12 @@ if (!isChrome && !isFirefox) {
 }
 
 const codeEditors = {};
-window.onEditorResized = () => {
-  setTimeout(() => {
-    for (let id in codeEditors) {
-      const textArea = document.getElementById(id);
-      if (textArea) {
-        const bbox = textArea.getBoundingClientRect();
-        codeEditors[id].setSize(bbox.width, bbox.height);
-      } else {
-        delete codeEditors[id];
-      }
-    }
-  }, 1);
+window.onEditorResized = () => {};
+
+window.createImJoyCodeEditor = async (name, type, arg) => {
+  await window.callPlugin("ImageJScriptEditor", "run", {
+    data: { arg, name, type }
+  });
 };
 
 // Returns a function, that, as long as it continues to be invoked, will not
@@ -481,7 +475,6 @@ async function startImageJ() {
       _addEL.apply(elm, [event, handler, options]);
     }
   };
-  fixWindowOrder();
   cheerpjRunMain("ij.ImageJ", "/app/ij153/ij-1.53g.jar");
 }
 
@@ -769,56 +762,6 @@ async function saveFileToFS(imagej, file) {
   console.log(await listFiles(imagej, "/files/"));
 }
 
-function fixWindowOrder() {
-  const cdisplay = document.getElementById("cheerpjDisplay");
-  const _appendChild = cdisplay.appendChild;
-  const sortByZIndex = function(a, b) {
-    return a.style.zIndex - b.style.zIndex;
-  };
-  function bringToTop(elm) {
-    const windows = Array.from(cdisplay.querySelectorAll(".window.bordered"));
-    let index = 0;
-    for (const w of windows.sort(sortByZIndex)) {
-      if (w === elm) {
-        w.style["z-index"] = windows.length + 1;
-      } else {
-        w.style["z-index"] = index;
-      }
-      index += 1;
-    }
-  }
-  cdisplay.appendChild = elm => {
-    try {
-      if (
-        elm.classList.contains("window") &&
-        elm.classList.contains("bordered")
-      ) {
-        bringToTop(bringToTop);
-        return;
-      }
-      elm.addEventListener("click", () => {
-        if (
-          elm.classList.contains("window") &&
-          elm.classList.contains("bordered")
-        ) {
-          bringToTop(elm);
-        }
-      });
-      setTimeout(() => {
-        if (
-          elm.classList.contains("window") &&
-          elm.classList.contains("bordered")
-        ) {
-          bringToTop(elm);
-        }
-      }, 100);
-      return _appendChild.apply(cdisplay, [elm]);
-    } catch (e) {
-      console.error(e);
-    }
-  };
-}
-
 async function fixMenu() {
   const removes = [
     "Open Recent",
@@ -839,30 +782,17 @@ async function fixMenu() {
       const el = it.parentNode;
       el.parentNode.removeChild(el);
     }
-    // else if (it.text === "Open...") {
-    //   const openNode = it.parentNode;
-    //   const openMenu = openNode.cloneNode(true);
-    //   it.text = "Open Internal"
-    //   openMenu.onclick = e => {
-    //     e.stopPropagation();
-    //     openImage(imagej);
-    //   };
-    //   openNode.parentNode.insertBefore(openMenu, openNode)
-    // }
   }
-
-  // addMenuItem({
-  //   label: "Debug",
-  //   async callback() {
-  //     const bytes = new ArrayBuffer(100*100*2);
-  //     const pixels = new Uint16Array(bytes);
-  //     for(let i=0;i<1000;i++){
-  //       pixels[i] = i;
-  //     }
-  //     const shape = Int16Array.from([1, 1, 1, 100, 100]);
-  //     await ij.createImagePlus(cjTypedArrayToJava(new Uint8Array(bytes)), 1, cjTypedArrayToJava(shape), "test image");
-  //   }
-  // });
+  addMenuItem({
+    label: "ImJoy Code Editor",
+    group: "Plugins",
+    position: "3.1",
+    async callback() {
+      await window.callPlugin("ImageJScriptEditor", "run", {
+        data: { name: "macro.ijm" }
+      }, null);
+    }
+  });
 }
 
 function setupDragDropPaste(imagej) {
@@ -1064,16 +994,32 @@ function addMenuItem(config) {
   };
   const index = menuIndexs[config.group || "Plugins"];
 
-  const targetMenu = document.querySelector(
+  let targetMenu = document.querySelector(
     `#cheerpjDisplay>.window>div.menuBar>.menu>.menuItem:nth-child(${index})>ul`
   );
-  for (let ch of targetMenu.children) {
-    if (ch.children[0].innerHTML === config.label) {
-      targetMenu.removeChild(ch);
-    }
-  }
+
   if (config.position) {
-    targetMenu.insertBefore(newMenu, targetMenu.children[config.position]);
+    if (typeof config.position === "number") {
+      for (let ch of targetMenu.children) {
+        if (ch.children[0].innerHTML === config.label) {
+          targetMenu.removeChild(ch);
+        }
+      }
+      targetMenu.insertBefore(newMenu, targetMenu.children[config.position]);
+    } else {
+      const [p1, p2] = config.position.split(".");
+      const menu = targetMenu.children[parseInt(p1)];
+      const subMenu = menu.querySelector(
+        `ul>.menuItem:nth-child(${parseInt(p2)})`
+      );
+      targetMenu = menu.querySelector("ul");
+      for (let ch of targetMenu.children) {
+        if (ch.children[0].innerHTML === config.label) {
+          targetMenu.removeChild(ch);
+        }
+      }
+      targetMenu.insertBefore(newMenu, subMenu);
+    }
   } else {
     targetMenu.appendChild(newMenu);
   }
@@ -1222,13 +1168,6 @@ function fixTouch() {
   for (let menu of menus) {
     menu.removeEventListener("touchstart", touchClick);
   }
-}
-
-function cheerpjRemoveStringFile(name) {
-  var mount = cheerpjGetFSMountForPath(name);
-  assert(mount instanceof CheerpJDataFolder);
-  const path = name.substr(mount.mountPoint.length - 1);
-  delete mount.files[path];
 }
 
 async function loadContentFromUrl(imagej, url) {
@@ -1454,11 +1393,8 @@ window.onImageJInitialized = async () => {
       imagej.runMacro(macro, args);
     });
   };
-  imagej.openAsync = function(url) {
-    return new Promise(resolve => {
-      window.onOpenResolve = resolve;
-      imagej.open(url);
-    });
+  imagej.openAsync = async function(url) {
+    await imagej.open(url);
   };
   window.ij = imagej;
   setupDragDropPaste(imagej);

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ window.shareViaQRCode = (name, content) => {
         type: "text/plain"
       });
       mountFile(file).then(filepath => {
-        ij.openAsync(filepath).finally(() => {
+        ij.open(filepath).finally(() => {
           cheerpjRemoveStringFile(filepath);
         });
       });
@@ -718,7 +718,7 @@ function downloadBytesFile(fileByteArray, filename) {
 
 function openImage(imagej, path) {
   if (path) {
-    return imagej.openAsync(path);
+    return imagej.open(path);
   }
   return new Promise((resolve, reject) => {
     const fileInput = document.getElementById("open-file");
@@ -736,7 +736,7 @@ function openImage(imagej, path) {
           mountFile(files[i])
             .then(filepath => {
               imagej
-                .openAsync(filepath)
+                .open(filepath)
                 .then(resolve)
                 .catch(reject)
                 .finally(() => {
@@ -819,7 +819,7 @@ function setupDragDropPaste(imagej) {
               type: "text/plain"
             });
             mountFile(file).then(filepath => {
-              imagej.openAsync(filepath).finally(() => {
+              imagej.open(filepath).finally(() => {
                 cheerpjRemoveStringFile(filepath);
               });
             });
@@ -831,7 +831,7 @@ function setupDragDropPaste(imagej) {
           saveFileToFS(imagej, file);
         } else {
           mountFile(file).then(filepath => {
-            imagej.openAsync(filepath).finally(() => {
+            imagej.open(filepath).finally(() => {
               cheerpjRemoveStringFile(filepath);
             });
           });
@@ -909,7 +909,7 @@ function setupDragDropPaste(imagej) {
                 { type: blob.type || type }
               );
               mountFile(file).then(filepath => {
-                imagej.openAsync(filepath).finally(() => {
+                imagej.open(filepath).finally(() => {
                   cheerpjRemoveStringFile(filepath);
                 });
               });
@@ -1186,7 +1186,7 @@ async function loadContentFromUrl(imagej, url) {
       url = tmp || url;
     }
 
-    await imagej.openAsync(url);
+    await imagej.open(url);
     Snackbar.show({
       text: "Successfully opened " + url,
       pos: "bottom-left"
@@ -1217,7 +1217,7 @@ async function processUrlParameters(imagej) {
             type: "text/plain"
           });
           mountFile(file).then(filepath => {
-            imagej.openAsync(filepath).finally(() => {
+            imagej.open(filepath).finally(() => {
               cheerpjRemoveStringFile(filepath);
             });
           });
@@ -1392,9 +1392,6 @@ window.onImageJInitialized = async () => {
       window.onMacroReject = resolve;
       imagej.runMacro(macro, args);
     });
-  };
-  imagej.openAsync = async function(url) {
-    await imagej.open(url);
   };
   window.ij = imagej;
   setupDragDropPaste(imagej);


### PR DESCRIPTION
This PR includes the following improvements:
 * Upgrade the loader which has supports for `cheerpjRemoveStringFile` and z-order based window management
 * Load imjoy code editor
 * Fix the bug related to multiple `open` or `run` in the URL (reported by @mutterer)