### PR TITLE
infer file type from content-type header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "ImageJ running in the browser",
   "main": "lib/index.js",
   "module": "src/index.js",


### PR DESCRIPTION
Requested by users on image.sc (https://forum.image.sc/t/open-an-image-from-omero-in-imagej-js/47747), when try to open files on omero, it failed because the url doesn't contain file extension (e.g. `.jpg`), this PR supports that by infer the file extension via Content-Type header of HTTP.