### PR TITLE
Fix mouse event in iframe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "ImageJ running in the browser",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -425,8 +425,8 @@ async function startImageJ() {
             e.target !== elm &&
             e.target.nodeName !== "TEXTAREA" &&
             e.target.getAttribute("role") !== "presentation" &&
-            window._imjoy_menu_element &&
-            !window._imjoy_menu_element.contains(e.target)
+            (!window._imjoy_menu_element ||
+              !window._imjoy_menu_element.contains(e.target))
           ) {
             handler.apply(null, [e]);
           } else {


### PR DESCRIPTION
The mouse event was not handled correct when ImageJ.JS is loaded as a plugin in an iframe, this is a fix for the issue.