### PR TITLE
Experimental support for NGFF, zarr and virtual stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ Close the virtual stack by its ID.
 Show a zarr image stored with [NGFF](https://ngff.openmicroscopy.org/latest/) format. The input argument `config` is an object contains the following field:
  * source: an URL or a valid Zarr store object
  * name: name of the image
+ * offsetX: starting position for x axis (used to display a small portion of the image plane)
+ * sizeX: the size for x axis (used to display a small portion of the image plane)
+ * offsetY: starting position for y axis (used to display a small portion of the image plane)
+ * sizeY: the size for y axis (used to display a small portion of the image plane)
 
 For example:
 ```js
@@ -175,7 +179,7 @@ await ij.viewZarr({source: "https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.z
 
 A Zarr store can be constructed in either Javascript or Python, for examples in Python please take a look at [vizarr](https://github.com/hms-dbmi/vizarr/tree/master/example).
 
-**Note: This function uses Virtual Stack in ImageJ to display, this means it will load the image plane as a whole -- as a result, it doesn't support loading image with large width and height (e.g. much less than 50000 pixels on each dimension ). You can however, make a stack with all the tiles.**
+**Note: This function uses Virtual Stack in ImageJ to display, this means it will load the image plane as a whole -- as a result, it doesn't support loading image with large width and height (e.g. much less than 50000 pixels on each dimension ). You will need to use `offsetX`, `offsetY`, `sizeX`, `sizeY` to crop the image plane.**
 ### getImage(format)
 
 Get the current image (current slice for a stack), for example, in Python you can get it as numpy array by setting the format to "ndarray".

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Close the virtual stack by its ID.
 ### viewZarr(config)
 **This function is in experimental state**
 Show a zarr image stored with [NGFF](https://ngff.openmicroscopy.org/latest/) format. The input argument `config` is an object contains the following field:
- * source: an URL or a valid Zarr store object
+ * source: an URL or a valid Zarr Group object
  * name: name of the image
  * offsetX: starting position for x axis (used to display a small portion of the image plane)
  * sizeX: the size for x axis (used to display a small portion of the image plane)
@@ -177,7 +177,7 @@ const ij = await api.getWindow("ImageJ.JS")
 await ij.viewZarr({source: "https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr", name: '6001240'})
 ```
 
-A Zarr store can be constructed in either Javascript or Python, for example:
+A Zarr Group object can be constructed in either Javascript or Python, for example:
 ```python
 from imjoy import api
 import zarr

--- a/README.md
+++ b/README.md
@@ -139,6 +139,43 @@ await ij.viewImage(image)
 
 If you pass raw bytes of an image in other formats, you need to specify the file name with the corresponding file extension. For example: `ij.viewImage(image_bytes, {"name": "my_image.png"})`.
 
+### openVirtualStack(img)
+**This function is in experimental state**
+
+Load a virtual stack that provide data in a lazy fashion. The input argument `img` should contain the following properties:
+ * name: String, the name of the virtual stack image
+ * dtype: String, the data type of the virtual stack image, should be one of the following: `"uint8"`, `"uint16"` or ``"float32"``.
+ * width: Integer, width of the virtual stack image
+ * height: Integer, height of the virtual stack image
+ * nSlices: Integer, the total number of slides in the virtual stack image
+ * getSlice: Function, a function that takes an index (`Integer`) as input and return the an `ArrayBuffer` (for Javascript) or `bytes` (for Python) with the specified image plane.
+
+If successful, it will return a virtual stack ID, with which you can close the virutal stack via `closeVirtualStack(ID)`.
+
+Note: this function can only support 3D image stack, if you want to load 4D or 5D images, you can run the `Stack to Hyperstack` macro to convert it into a Hyperstack, for example:
+```js
+await ij.runMacro(`run("Stack to Hyperstack...", "order=xyzct channels=4 slices=30 frames=10 display=Grayscale");`)
+```
+### closeVirtualStack(id)
+**This function is in experimental state**
+
+Close the virtual stack by its ID.
+
+### viewZarr(config)
+**This function is in experimental state**
+Show a zarr image stored with [NGFF](https://ngff.openmicroscopy.org/latest/) format. The input argument `config` is an object contains the following field:
+ * source: an URL or a valid Zarr store object
+ * name: name of the image
+
+For example:
+```js
+const ij = await api.getWindow("ImageJ.JS")
+await ij.viewZarr({source: "https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr", name: '6001240'})
+```
+
+A Zarr store can be constructed in either Javascript or Python, for examples in Python please take a look at [vizarr](https://github.com/hms-dbmi/vizarr/tree/master/example).
+
+**Note: This function uses Virtual Stack in ImageJ to display, this means it will load the image plane as a whole -- as a result, it doesn't support loading image with large width and height (e.g. much less than 50000 pixels on each dimension ). You can however, make a stack with all the tiles.**
 ### getImage(format)
 
 Get the current image (current slice for a stack), for example, in Python you can get it as numpy array by setting the format to "ndarray".

--- a/README.md
+++ b/README.md
@@ -177,7 +177,34 @@ const ij = await api.getWindow("ImageJ.JS")
 await ij.viewZarr({source: "https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001240.zarr", name: '6001240'})
 ```
 
-A Zarr store can be constructed in either Javascript or Python, for examples in Python please take a look at [vizarr](https://github.com/hms-dbmi/vizarr/tree/master/example).
+A Zarr store can be constructed in either Javascript or Python, for example:
+```python
+from imjoy import api
+import zarr
+from fsspec.implementations.http import HTTPFileSystem
+
+from imjoy_rpc import register_default_codecs
+
+register_default_codecs()
+fs = HTTPFileSystem()
+
+class Plugin:
+    async def setup(self):
+        pass
+
+    async def run(self, ctx):
+        ij = await api.createWindow(
+            type="ImageJ.JS", src="https://ij.imjoy.io"
+        )
+        
+        http_map = fs.get_mapper('https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001237.zarr')
+        z_group = zarr.open(http_map, mode='r')
+        await ij.viewZarr({"source": z_group})
+
+
+api.export(Plugin())
+```
+For more Python examples, you can also take a look at the [vizarr](https://github.com/hms-dbmi/vizarr/tree/master/example) repo.
 
 **Note: This function uses Virtual Stack in ImageJ to display, this means it will load the image plane as a whole -- as a result, it doesn't support loading image with large width and height (e.g. much less than 50000 pixels on each dimension ). You will need to use `offsetX`, `offsetY`, `sizeX`, `sizeY` to crop the image plane.**
 ### getImage(format)

--- a/src/imjoyAPI.js
+++ b/src/imjoyAPI.js
@@ -1,5 +1,6 @@
 import { setupRPC } from "imjoy-rpc";
 import { version, description } from "../package.json";
+import { loadZarrImage } from "./zarrUtils";
 
 export async function setupImJoyAPI(
   api,
@@ -80,6 +81,21 @@ export async function setupImJoyAPI(
     },
     runPlugIn(className, args) {
       imagej.runPlugIn(className, args || "");
+    },
+    async openVirtualStack(img) {
+      return await imagej.openVirtualStack(img);
+    },
+    async closeVirtualStack(key) {
+      await imagej.closeVirtualStack(key);
+    },
+    async viewZarr(config) {
+      config = config || {};
+      const img = await loadZarrImage(config);
+      await imagej.openVirtualStack(img);
+      if (img.sizeT > 1 || img.sizeZ > 1)
+        await ij.runMacro(
+          `run("Stack to Hyperstack...", "order=xyzct channels=${img.sizeC} slices=${img.sizeZ} frames=${img.sizeT} display=Grayscale");`
+        );
     },
     async viewImage(img, options) {
       loader.style.display = "block";

--- a/src/imjoyApp.js
+++ b/src/imjoyApp.js
@@ -5,7 +5,7 @@ const builtinPlugins = [
   "https://gist.githubusercontent.com/oeway/9c78d23c101f468e723888d05b6fac6d/raw/ImageJScriptEditor.imjoy.html",
   "https://gist.githubusercontent.com/oeway/c9592f23c7ee147085f0504d2f3e993a/raw/CellPose-ImageJ.imjoy.html",
   "https://gist.githubusercontent.com/oeway/e5c980fbf6582f25fde795262a7e33ec/raw/itk-vtk-viewer-imagej.imjoy.html",
-  "https://gist.githubusercontent.com/oeway/16d189e53d23cb2e26c3618ed6e40be6/raw/ImJoyModelRunner.imjoy.html",
+  "https://gist.githubusercontent.com/oeway/16d189e53d23cb2e26c3618ed6e40be6/raw/ImJoyModelRunner.imjoy.html"
 ];
 async function startImJoy(app, imjoy) {
   await imjoy.start();
@@ -170,11 +170,10 @@ async function startImJoy(app, imjoy) {
   };
 
   window.loadPlugin = async function(uri) {
-    await imjoy.pm
-      .reloadPluginRecursively({
-        uri
-      })
-  }
+    await imjoy.pm.reloadPluginRecursively({
+      uri
+    });
+  };
 
   window.callPlugin = async function(pluginName, functionName) {
     let args = Array.prototype.slice.call(arguments).slice(2);

--- a/src/zarrUtils.js
+++ b/src/zarrUtils.js
@@ -1,0 +1,85 @@
+let zarrLib;
+export async function loadZarrImage(config) {
+  config = config || {};
+  if (!config.source) {
+    throw new Error("source field is missing.");
+  }
+  if (!zarrLib)
+    zarrLib = await import(
+      /* webpackIgnore: true */ "https://cdn.skypack.dev/@manzt/zarr-lite"
+    );
+
+  let store;
+  if (typeof config.source === "string" && config.source.startsWith("http")) {
+    config.name =
+      config.name ||
+      config.source
+        .split("/")
+        .pop()
+        .split("#")[0]
+        .split("?")[0];
+    store = new zarrLib.HTTPStore(config.source);
+  } else if (typeof config.source === "object" && config.source.getItem) {
+    store = config.source;
+  } else {
+    throw new Error("Invalid source, it must be an URL or a zarr store.");
+  }
+
+  config.name = config.name || "zarr image";
+
+  async function loadPyramid() {
+    const rootAttrs = await zarrLib.getJson(store, ".zattrs");
+    console.log("rootAttrs", rootAttrs);
+    let paths = [];
+    if ("multiscales" in rootAttrs) {
+      const { datasets } = rootAttrs.multiscales[0];
+      paths = datasets.map(d => d.path);
+    }
+    const p = paths.map(path =>
+      zarrLib.openArray({
+        store,
+        path
+      })
+    );
+    return Promise.all(p);
+  }
+
+  const pyramid = await loadPyramid();
+  const zarr_arr = pyramid[0];
+
+  let [sizeT, sizeC, sizeZ, sizeY, sizeX] = zarr_arr.shape;
+
+  const dtypes = {
+    "|i1": "int8",
+    "|u1": "uint8",
+    "<i2": "int16",
+    "<u2": "uint16",
+    "<i4": "int32",
+    "<u4": "uint32",
+    "<f4": "float32",
+    "<f8": "float64"
+  };
+
+  if (sizeX * sizeY > 50000 * 50000) {
+    throw new Error("The image size exceeded the limit for ImageJ.JS.");
+  }
+
+  return {
+    name: config.name,
+    dtype: dtypes[zarr_arr.dtype] || "uint16",
+    width: sizeX,
+    height: sizeY,
+    nSlice: sizeC * sizeZ * sizeT,
+    sizeC,
+    sizeZ,
+    sizeT,
+    async getSlice(index) {
+      const t = parseInt(index / (sizeC * sizeZ));
+      const c = parseInt(index / sizeZ);
+      const z = parseInt(index % sizeZ);
+      // const d = await zarr_arr.getRawChunk([t, c, z, 0, 0]);
+      const d = await zarr_arr.getRaw([t, c, z, null, null]);
+      return d.data.buffer;
+    }
+  };
+}


### PR DESCRIPTION
We can support displaying lazy virtual stack, we just need to define the size of the stack as well as a `getSlice` function. This can be then implemented in JS or even Python, see the README for more details.


In the screenshot below, we loaded a zarr file in Python, then use ImageJ.JS to display it in a lazy fashion, when we scrolll the Z slider, it dynamically request a new image from Python.

<img width="1173" alt="Screenshot 2021-05-18 at 20 22 42" src="https://user-images.githubusercontent.com/478667/118703896-dd81e180-b816-11eb-9e2b-e32bc3f39452.png">


Closes https://github.com/imjoy-team/imagej.js/issues/53
