### PR TITLE
Improve imagej menu z-order

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -767,7 +767,17 @@ async function fixZOrder() {
   const ijWindow = document.querySelector(
     "#cheerpjDisplay>.window:nth-child(2)"
   );
-  ijWindow.classList.add("always-top");
+
+  ijWindow.addEventListener("mouseenter", () => {
+    ijWindow.classList.add("always-top");
+  });
+  ijWindow.addEventListener("mouseleave", () => {
+    ijWindow.classList.remove("always-top");
+  });
+  const menuBar = ijWindow.querySelector(".menuBar");
+  menuBar.addEventListener("mousedown", () => {
+    ijWindow.classList.add("always-top");
+  });
 }
 
 async function fixMenu() {

--- a/src/zarrUtils.js
+++ b/src/zarrUtils.js
@@ -94,6 +94,6 @@ export async function loadZarrImage(config) {
     },
     sizeC,
     sizeZ,
-    sizeT,
+    sizeT
   };
 }


### PR DESCRIPTION
Previously, we make the imagej window always on top to make sure users can always use the menu, however, all the other window can sometimes hide below the imagej window and one have to minimize the imagej window (for example in [this video](https://www.youtube.com/watch?v=-T2q1dJ5UuE) 
 made by others). 

Here we use a different approach to solve the problem, now the imagej window is not always on top, but only when the user hover on top of the window: 
![imagej-z-order](https://user-images.githubusercontent.com/478667/119642709-4a9b0580-be1b-11eb-8e04-b5429055df87.gif)
