### PR TITLE
Support install macro/tool from URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagej.js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "ImageJ running in the browser",
   "main": "lib/index.js",
   "module": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1340,6 +1340,66 @@ async function loadContentFromUrl(imagej, url) {
 async function processUrlParameters(imagej) {
   const queryString = window.location.search;
   const urlParams = new URLSearchParams(queryString);
+  if (urlParams.has("install-tool")) {
+    const urls = urlParams.getAll("install-tool");
+    for (let url of urls) {
+      let script;
+      if (url.startsWith("http")) {
+        if (url.includes("//zenodo.org/record")) {
+          url = await convertZenodoFileUrl(url);
+        } else {
+          const tmp =
+            (await githubUrlRaw(url, ".ijm")) ||
+            (await githubUrlRaw(url, ".txt"));
+          url = tmp || url;
+        }
+        const response = await fetch(url);
+        if (!response.ok) {
+          alert("Failed to install tool from url:" + url);
+          return;
+        }
+        script = await response.text();
+      } else {
+        const decompressed = LZString.decompressFromEncodedURIComponent(url);
+        if (decompressed) {
+          script = JSON.parse(decompressed);
+        } else {
+          console.error("Failed to decompress url: ", url);
+        }
+      }
+      if (script) await window.ij.installTool(script);
+      else alert("No script found");
+    }
+  }
+  if (urlParams.has("install-macro")) {
+    const urls = urlParams.getAll("install-macro");
+    for (let url of urls) {
+      let script;
+      if (url.startsWith("http")) {
+        if (url.includes("//zenodo.org/record")) {
+          url = await convertZenodoFileUrl(url);
+        } else {
+          const tmp = await githubUrlRaw(url, ".ijm");
+          url = tmp || url;
+        }
+        const response = await fetch(url);
+        if (!response.ok) {
+          alert("Failed to install macro from url:" + url);
+          return;
+        }
+        script = await response.text();
+      } else {
+        const decompressed = LZString.decompressFromEncodedURIComponent(url);
+        if (decompressed) {
+          script = JSON.parse(decompressed);
+        } else {
+          console.error("Failed to decompress url: ", url);
+        }
+      }
+      if (script) await window.ij.installMacro(script);
+      else alert("No script found");
+    }
+  }
   if (urlParams.has("open")) {
     const urls = urlParams.getAll("open");
     for (let url of urls) {


### PR DESCRIPTION
As requested by @mutterer , it would be nice allow loading tool and macro from URL query (`install-tool` and `install-macro`). For example: `https://ij.imjoy.io/?install-tool=https://github.com/imagej/ij1-installer/blob/master/app/macros/tools/GetCursorLocDemoTool.txt`

Try it here: https://deploy-preview-65--imagej.netlify.app/?install-tool=https://github.com/imagej/ij1-installer/blob/master/app/macros/tools/GetCursorLocDemoTool.txt


Fixes https://github.com/imjoy-team/imagej.js/issues/64